### PR TITLE
Fix vanilla bridge logic to also require the light arrows

### DIFF
--- a/State.py
+++ b/State.py
@@ -385,7 +385,7 @@ class State(object):
         if self.world.bridge == 'open':
             return True
         if self.world.bridge == 'vanilla':
-            return self.has_all_of(('Shadow Medallion', 'Spirit Medallion'))
+            return self.has_all_of(('Shadow Medallion', 'Spirit Medallion', 'Light Arrows'))
         if self.world.bridge == 'stones':
             return self.has_all_stones()
         if self.world.bridge == 'medallions':


### PR DESCRIPTION
Looks like this requirement got lost during TR's bridge logic refactor, back when triforce hunt was being actively worked on.